### PR TITLE
Letterboxd list support

### DIFF
--- a/example_config.ini
+++ b/example_config.ini
@@ -1,6 +1,9 @@
 [Letterboxd]
 usernames = username1
             username2
+lists = ironmansucks/list/2017-year-in-film
+        stu93/list/war-top-10
+
 
 [Radarr]
 api_key = 1235232132142312

--- a/letterboxd_helpers.py
+++ b/letterboxd_helpers.py
@@ -1,0 +1,57 @@
+"""
+"""
+import tmdb_info
+import requests
+import os
+import json
+from bs4 import BeautifulSoup
+from log import log_to_file
+
+class Letterboxd_Helpers():
+    def compare_movies_to_json(self, movies, json_path):
+        """Compare an array of TMDB_Info object titles to movies stored in JSON."""
+        if os.path.exists(json_path):
+            with open(json_path, 'r') as outfile:
+                saved_movies = json.load(outfile)
+        
+            new_movies = []
+            for i in movies:
+                if i.title not in saved_movies:
+                    new_movies.append(i)
+            
+            return new_movies
+
+        else:
+            return movies
+
+    def create_tmdb_obj(self, letterboxd_response):
+        """Create TMDB_Info objects from info parsed from a letterboxd movie page."""
+        try:
+            soup = BeautifulSoup(letterboxd_response.text, 'html.parser')
+
+            tmdb_element = soup.find('a', attrs={'data-track-action' : 'TMDb'})
+            tmdb_url = tmdb_element.get('href')
+            if 'tv' in tmdb_url:
+                return None    
+            else:
+                tmdb_id = (tmdb_url.split('/movie/',1)[1]).replace('/','')
+
+            film_title_element = soup.find('h1', attrs={'itemprop' : 'name'})
+            film_title = film_title_element.get_text()
+
+            film_image_element = soup.find('img', attrs={'itemprop' : 'image'})
+            film_image = film_image_element.get('src')
+
+            date_published_element = soup.find('small', attrs={'itemprop' : 'datePublished'})
+            date_anchor = date_published_element.find('a')
+            film_published_date = date_anchor.get_text()
+
+            tmdb_obj = tmdb_info.TMDB_Info(film_title, film_published_date, tmdb_id, film_image)
+
+            return tmdb_obj
+        except TypeError as e:
+            log_to_file('TypeError while creating tmdb_obj: {0} \n'.format(e))
+        except Exception as e:
+            log_to_file('Failure while creating tmdb_obj: {0} \n'.format(e))
+            log_to_file('Exception Args: {0} \n'.format(e.args))
+            raise Exception('Failure while creating tmdb_obj')

--- a/letterboxd_lists.py
+++ b/letterboxd_lists.py
@@ -1,0 +1,70 @@
+"""
+"""
+
+import tmdb_info
+import requests
+import os
+import json
+from letterboxd_helpers import Letterboxd_Helpers
+from bs4 import BeautifulSoup
+from config_mapper import ConfigParse
+from log import log_to_file
+
+class Letterboxd_Lists():
+
+    def __init__(self):
+        config = ConfigParse('config.ini')
+
+        self.LETTERBOXD_LISTURLS_PREFORMATED = config.ConfigSectionMap('Letterboxd')['lists']
+        self.LETTERBOXD_LISTS = self.LETTERBOXD_LISTURLS_PREFORMATED.split()
+        self.helpers = Letterboxd_Helpers()
+    
+    def get_lists(self):
+        movies = []
+
+        for list_url in self.LETTERBOXD_LISTS:
+            try:
+                letterboxd_page_req = requests.get('https://letterboxd.com/' + list_url)
+                soup = BeautifulSoup(letterboxd_page_req.text , 'html.parser')
+
+                if(soup.find_all(class_='paginate-page')):
+                    pages = soup.find_all(class_='paginate-page')
+                    for page_element in pages:pass
+                    if page_element :
+                        num_of_pages = int(page_element .getText())
+                    else:
+                        num_of_pages = len(pages)
+                    for page_num in range(1, num_of_pages + 1):
+
+                        page_request = requests.get('https://letterboxd.com/{}/page/{}'.format(list_url, page_num))
+                        page_soup = BeautifulSoup(page_request.text, 'html.parser')
+
+                        for frame_title in page_soup.find_all('div', class_='film-poster'):
+                            letterboxd_url_sub = frame_title.get('data-film-slug')
+                            letterboxd_film_url = 'https://letterboxd.com{}'.format(letterboxd_url_sub)
+                            film_page_request = requests.get(letterboxd_film_url, allow_redirects=False)
+                            if (film_page_request.status_code in [200,201,202,203,204,205,206]):
+                                tmdb_obj = self.helpers.create_tmdb_obj(film_page_request)
+                                if(tmdb_obj):
+                                    movies.append(tmdb_obj)
+                            else:
+                                log_to_file("{} was unavailable \n".format(letterboxd_film_url, allow_redirects=False))
+                else:
+                    for frame_title in soup.find_all('div', class_='film-poster'):
+                        letterboxd_url_sub = frame_title.get('data-film-slug')
+                        letterboxd_film_url = 'https://letterboxd.com{}'.format(letterboxd_url_sub)
+                        film_page_request = requests.get(letterboxd_film_url, allow_redirects=False)
+                        tmdb_obj = self.helpers.create_tmdb_obj(film_page_request)
+                        if(tmdb_obj):
+                            movies.append(tmdb_obj)
+            except Exception as e:
+                log_to_file('There was an error retrieving films from Letterboxd: {0} \n'.format(e))
+                raise Exception('There was an error retrieving films from Letterboxd')
+        return movies
+
+if __name__ == '__main__':
+    letter = Letterboxd_Lists()
+    movies = letter.get_lists()
+    for movie in movies:
+        print(movie.title + '\n')
+

--- a/letterboxd_watchlist.py
+++ b/letterboxd_watchlist.py
@@ -7,17 +7,19 @@ import tmdb_info
 import requests
 import os
 import json
+from letterboxd_helpers import Letterboxd_Helpers
 from bs4 import BeautifulSoup
 from config_mapper import ConfigParse
 from log import log_to_file
 
-class Letterboxd():
+class Letterboxd_Watchlist():
 
     def __init__(self):
         config = ConfigParse('config.ini')
 
         self.LETTERBOXD_USERNAMES_PREFORMATED = config.ConfigSectionMap('Letterboxd')['usernames']
         self.LETTERBOXD_USERNAMES = self.LETTERBOXD_USERNAMES_PREFORMATED.split()
+        self.helpers = Letterboxd_Helpers()
     
     def get_watchlist(self):
         """ Grab all movies from watchlists and return in an array of tmdb_info objects."""
@@ -25,12 +27,16 @@ class Letterboxd():
         movies = []
         for username in self.LETTERBOXD_USERNAMES:
             try:
-                requests.get('https://letterboxd.com/' + username + '/watchlist/')
                 letterboxd_page_req = requests.get('https://letterboxd.com/' + username + '/watchlist/')
                 soup = BeautifulSoup(letterboxd_page_req.text , 'html.parser')
 
                 if(soup.find_all(class_='paginate-page')):
-                    num_of_pages = len(soup.find_all(class_='paginate-page'))
+                    pages = soup.find_all(class_='paginate-page')
+                    for page_element in pages:pass
+                    if page_element :
+                        num_of_pages = int(page_element .getText())
+                    else:
+                        num_of_pages = len(pages)
 
                     for page_num in range(1, num_of_pages + 1):
                         page_request = requests.get('https://letterboxd.com/{}/watchlist/page/{}'.format(username, page_num))
@@ -41,63 +47,20 @@ class Letterboxd():
                             letterboxd_film_url = 'https://letterboxd.com{}'.format(letterboxd_url_sub)
                             film_page_request = requests.get(letterboxd_film_url, allow_redirects=False)
                             if (film_page_request.status_code in [200,201,202,203,204,205,206]):
-                                tmdb_obj = self.create_tmdb_obj(film_page_request)
-                                movies.append(tmdb_obj)
+                                tmdb_obj = self.helpers.create_tmdb_obj(film_page_request)
+                                if(tmdb_obj):
+                                    movies.append(tmdb_obj)
                             else:
                                 log_to_file("{} was unavailable \n".format(letterboxd_film_url, allow_redirects=False))
                 else:
                     for frame_title in soup.find_all('div', class_='film-poster'):
                         letterboxd_url_sub = frame_title.get('data-film-slug')
                         letterboxd_film_url = 'https://letterboxd.com{}'.format(letterboxd_url_sub)
-                        tmdb_obj = self.create_tmdb_obj(letterboxd_film_url)
-                        movies.append(tmdb_obj)
+                        film_page_request = requests.get(letterboxd_film_url, allow_redirects=False)
+                        tmdb_obj = self.helperscreate_tmdb_obj(film_page_request)
+                        if(tmdb_obj):
+                            movies.append(tmdb_obj)
             except Exception as e:
                 log_to_file('There was an error retrieving films from Letterboxd: {0} \n'.format(e))
                 raise Exception('There was an error retrieving films from Letterboxd')
         return movies
-
-    def compare_movies_to_json(self, movies, json_path):
-        """Compare an array of TMDB_Info object titles to movies stored in JSON."""
-
-        if os.path.exists(json_path):
-            with open(json_path, 'r') as outfile:
-                saved_movies = json.load(outfile)
-        
-            new_movies = []
-            for i in movies:
-                if i.title not in saved_movies:
-                    new_movies.append(i)
-            
-            return new_movies
-
-        else:
-            return movies
-
-    def create_tmdb_obj(self, letterboxd_response):
-        """Create TMDB_Info objects from info parsed from a letterboxd movie page."""
-        try:
-            soup = BeautifulSoup(letterboxd_response.text, 'html.parser')
-
-            tmdb_element = soup.find('a', attrs={'data-track-action' : 'TMDb'})
-            tmdb_url = tmdb_element.get('href')
-            tmdb_id = (tmdb_url.split('/movie/',1)[1]).replace('/','')
-
-            film_title_element = soup.find('h1', attrs={'itemprop' : 'name'})
-            film_title = film_title_element.get_text()
-
-            film_image_element = soup.find('img', attrs={'itemprop' : 'image'})
-            film_image = film_image_element.get('src')
-
-            date_published_element = soup.find('small', attrs={'itemprop' : 'datePublished'})
-            date_anchor = date_published_element.find('a')
-            film_published_date = date_anchor.get_text()
-
-            tmdb_obj = tmdb_info.TMDB_Info(film_title, film_published_date, tmdb_id, film_image)
-
-            return tmdb_obj
-        except TypeError as e:
-            log_to_file('TypeError while creating tmdb_obj: {0} \n'.format(e))
-        except Exception as e:
-            log_to_file('Failure while creating tmdb_obj: {0} \n'.format(e))
-            log_to_file('Exception Args: {0} \n'.format(e.args))
-            raise Exception('Failure while creating tmdb_obj')

--- a/main.py
+++ b/main.py
@@ -28,10 +28,10 @@ def main():
     new_movie_titles = []
     for movie in new_movies:
         print("Adding Movie: {}".format(movie.title))
-        #radarr.add_movie_to_radarr(movie)
-        #new_movie_titles.append(movie.title)
+        radarr.add_movie_to_radarr(movie)
+        new_movie_titles.append(movie.title)
         
-    #radarr.write_to_json(new_movie_titles)
+    radarr.write_to_json(new_movie_titles)
 if __name__ == '__main__':
     start_time = time.time()
 

--- a/main.py
+++ b/main.py
@@ -5,28 +5,33 @@ the movies found into Radarr if they do not already exist
 
 import sched
 import time
-from letterboxd import Letterboxd
+from letterboxd_watchlist import Letterboxd_Watchlist
+from letterboxd_helpers import Letterboxd_Helpers
+from letterboxd_lists import Letterboxd_Lists
 from radarr import Radarr
 
 
 def main():
-    letter = Letterboxd()
+    letterboxd_watchlist = Letterboxd_Watchlist()
+    letterboxd_lists = Letterboxd_Lists()
+    letterboxd_helpers = Letterboxd_Helpers()
     radarr = Radarr()
     
     radarr_movies = radarr.get_movies()
     new_radarr_movies = radarr.compare_movies_to_json(radarr_movies)
     radarr.write_to_json(new_radarr_movies)
 
-    letterboxd_movies = letter.get_watchlist()
-    new_movies = letter.compare_movies_to_json(letterboxd_movies, radarr.RADARR_JSON_PATH)
+    letterboxd_watchlist_movies = letterboxd_watchlist.get_watchlist()
+    letterboxd_list_movies = letterboxd_lists.get_lists()
+    letterboxd_movies = list(set(letterboxd_watchlist_movies + letterboxd_list_movies))
+    new_movies = letterboxd_helpers.compare_movies_to_json(letterboxd_movies, radarr.RADARR_JSON_PATH)
     new_movie_titles = []
-
     for movie in new_movies:
         print("Adding Movie: {}".format(movie.title))
-        radarr.add_movie_to_radarr(movie)
-        new_movie_titles.append(movie.title)
+        #radarr.add_movie_to_radarr(movie)
+        #new_movie_titles.append(movie.title)
         
-    radarr.write_to_json(new_movie_titles)
+    #radarr.write_to_json(new_movie_titles)
 if __name__ == '__main__':
     start_time = time.time()
 


### PR DESCRIPTION
Adding support for letterboxd lists. Added in the same way as usernames in config.ini, ex:

lists = jhillman/list/they-shoot-zombies-dont-they-the-1000-greatest-3
           johnfilms/list/best-science-fiction-films-of-the-2010s

Just take everything after https://www.letterboxd.com/

Also fixed some bugs that I found due to implementing lists.
 - Added support for short (1 page) and long (over 5 page) lists and watchlists
 - Fixed error handling for letterboxd movies that use the tv instead of movie for tmdb. Currently this is just unsupported by Radarr so we skip any movie that is on the tv portion of tmdb. 
